### PR TITLE
Remove tzinfo-data warning

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -71,4 +71,4 @@ group :production do
 end
 
 # Timezone Data
-gem 'tzinfo-data', platforms: [:mingw, :mswin, :jruby]
+gem 'tzinfo-data'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -260,6 +260,8 @@ GEM
     tilt (2.0.10)
     tzinfo (1.2.7)
       thread_safe (~> 0.1)
+    tzinfo-data (1.2020.4)
+      tzinfo (>= 1.0.0)
     uglifier (4.2.0)
       execjs (>= 0.3.0, < 3)
     web-console (4.0.4)


### PR DESCRIPTION
```
The dependency tzinfo-data (>= 0) will be unused by any of the platforms
Bundler is installing for. Bundler is installing for ruby but the
dependency is only for x86-mingw32, x86-mswin32, java. To add those
platforms to the bundle, run `bundle lock --add-platform x86-mingw32
x86-mswin32 java`.
```